### PR TITLE
Moved a variable definition to the correct place, and fixed a wrongly us...

### DIFF
--- a/cram_moveit/cram-moveit.asd
+++ b/cram_moveit/cram-moveit.asd
@@ -41,8 +41,8 @@
                actionlib
                std_msgs-msg
                cram-plan-failures
-               moveit_msgs-srv
-               moveit_msgs-msg)
+               moveit_msgs-msg
+               moveit_msgs-srv)
   :components
   ((:module "src"
     :components

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -50,6 +50,8 @@
 (defvar *known-collision-objects* nil
   "List of collision object instances registered with the CRAM/MoveIt!
 bridge.")
+(defvar *planning-scene-publisher* nil
+  "Publisher handle for the planning scene topic.")
 
 (defgeneric register-collision-object (object &rest rest))
 

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -28,8 +28,6 @@
 (in-package :cram-moveit)
 
 (defvar *move-group-action-client* nil)
-(defvar *planning-scene-publisher* nil
-  "Publisher handle for the planning scene topic.")
 (defvar *attached-object-publisher* nil
   "Publisher handle for attaching and detaching collicion objects through /attached_collision_object.")
 (defvar *joint-states-fluent* nil
@@ -368,7 +366,7 @@
 (defun compute-ik (link-name planning-group pose-stamped)
   (let ((result (roslisp:call-service
                  "/compute_ik"
-                 'moveit_msgs-srv:getpositionik
+                 "moveit_msgs/GetPositionIK"
                  :ik_request
                  (make-message
                   "moveit_msgs/PositionIKRequest"


### PR DESCRIPTION
...ed service type (again)

Since the services for MoveIt! are not loadable properly when loaded at the same time as their messages, they are now referred to in a different manner in code. This way, it should work without loading problems.
