### PR TITLE
Return log-id when starting WFH block

### DIFF
--- a/cram_beliefstate/src/hooks.lisp
+++ b/cram_beliefstate/src/hooks.lisp
@@ -358,7 +358,8 @@
       (mapcar (lambda (clause)
                 `(clause ,clause))
               clauses))
-     id :annotation "with-failure-handling-clauses")))
+     id :annotation "with-failure-handling-clauses")
+    id))
 
 (defmethod cram-language::on-with-failure-handling-handled cram-beliefstate (id)
   (catch-current-failure-with-active-node id))


### PR DESCRIPTION
This one is important: Caught failures would sometimes not be correlated to the correct throwing task instance due to a missing return statement here.

This finally fixes that issue.