### PR TITLE
tf -> tf2

### DIFF
--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -154,7 +154,7 @@ bridge.")
     (unless (or primitive-shapes mesh-shapes plane-shapes)
       (cpl:fail 'no-collision-shapes-defined))
     (flet* ((resolve-pose (pose-msg)
-              (or pose-msg (tf:pose->msg pose-stamped)))
+                          (or pose-msg (cl-tf2:to-msg pose-stamped)))
             (pose-present (object)
               (and (listp object) (cdr object)))
             (resolve-object (obj)
@@ -165,8 +165,8 @@ bridge.")
               (map 'vector #'resolve-pose (mapcar #'pose-present poses))))
       (let* ((obj-msg (roslisp:make-msg
                        "moveit_msgs/CollisionObject"
-                       (stamp header) (tf:stamp pose-stamped)
-                       (frame_id header) (tf:frame-id pose-stamped)
+                       (stamp header) (cl-tf-datatypes:stamp pose-stamped)
+                       (frame_id header) (cl-tf-datatypes:frame-id pose-stamped)
                        id name
                        operation (roslisp-msg-protocol:symbol-code
                                   'moveit_msgs-msg:collisionobject
@@ -285,11 +285,14 @@ bridge.")
             (mesh-shapes (slot-value col-obj 'mesh-shapes))
             (plane-shapes (slot-value col-obj 'plane-shapes)))
         (roslisp:ros-info (moveit) "Transforming link from ~a into ~a"
-                          (tf:frame-id current-pose-stamped)
+                          (cl-tf-datatypes:frame-id current-pose-stamped)
                           target-link)
         (let* ((pose-in-link
-                 (cl-tf2:ensure-pose-stamped-transformed
-                  *tf2* current-pose-stamped target-link
+                 (cl-tf2:transform-pose
+                  *tf2-buffer*
+                  :pose current-pose-stamped
+                  :target-frame target-link
+                  :timeout cram-roslisp-common:*tf-default-timeout*
                   :use-current-ros-time t))
                (obj-msg-plain (create-collision-object-message
                                name pose-in-link
@@ -341,18 +344,20 @@ bridge.")
             (mesh-shapes (slot-value col-obj 'mesh-shapes))
             (plane-shapes (slot-value col-obj 'plane-shapes))
             (time (roslisp:ros-time)))
-        (unless (tf:wait-for-transform
-                 *tf*
-                 :timeout 5.0
-                 :time time
-                 :source-frame (tf:frame-id current-pose-stamped)
-                 :target-frame target-link)
-          (cpl:fail 'pose-not-transformable-into-link))
-        (let* ((pose-in-link (cl-tf2:ensure-pose-stamped-transformed
-                              *tf2* (tf:copy-pose-stamped
+        ;; (unless (cl-tf:wait-for-transform
+        ;;          *tf*
+        ;;          :timeout 5.0
+        ;;          :time time
+        ;;          :source-frame (cl-tf-datatypes:frame-id current-pose-stamped)
+        ;;          :target-frame target-link)
+        ;;   (cpl:fail 'pose-not-transformable-into-link))
+        (let* ((pose-in-link (cl-tf2:transform-pose
+                              *tf2-buffer*
+                              :pose (cl-tf-datatypes:copy-pose-stamped
                                      current-pose-stamped
                                      :stamp time)
-                              target-link :use-current-ros-time t))
+                              :target-frame target-link
+                              :timeout cram-roslisp-common:*tf-default-timeout*))
                (obj-msg-plain (create-collision-object-message
                                name pose-in-link
                                :primitive-shapes primitive-shapes
@@ -385,4 +390,4 @@ bridge.")
           (roslisp:ros-info
            (moveit)
            "Detaching collision object `~a' from link `~a'."
-           name (tf:frame-id current-pose-stamped)))))))
+           name (cl-tf-datatypes:frame-id current-pose-stamped)))))))

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -77,7 +77,11 @@ MoveIt! framework and registers known conditions."
                          (wait-for-execution t)
                          max-tilt
                          reference-frame)
-  "Calls the MoveIt! MoveGroup action. The link identified by `link-name' is tried to be positioned in the pose given by `pose-stamped'. Returns `T' on success and `nil' on failure, in which case a failure condition is signalled, based on the error code returned by the MoveIt! service (as defined in
+  "Calls the MoveIt! MoveGroup action. The link identified by
+  `link-name' is tried to be positioned in the pose given by
+  `pose-stamped'. Returns `T' on success and `nil' on failure, in
+  which case a failure condition is signalled, based on the error code
+  returned by the MoveIt! service (as defined in
   moveit_msgs/MoveItErrorCodes)."
   ;; NOTE(winkler): Since MoveIt! crashes once it receives a frame-id
   ;; which includes the "/" character at the beginning, we change the
@@ -105,10 +109,10 @@ MoveIt! framework and registers known conditions."
                                          (t `(,link-name))))
                        (poses-stamped (mapcar
                                        (lambda (pose-stamped)
-                                         (tf:pose->pose-stamped
-                                          (cl-tf2:unslash-frame (tf:frame-id
-                                                                 pose-stamped))
-                                          (tf:stamp pose-stamped)
+                                         (cl-tf-datatypes:pose->pose-stamped
+                                          (cl-tf2:unslash-frame
+                                           (cl-tf-datatypes:frame-id pose-stamped))
+                                          (cl-tf-datatypes:stamp pose-stamped)
                                           pose-stamped))
                                        (cond ((listp pose-stamped) pose-stamped)
                                              (t `(,pose-stamped)))))
@@ -120,7 +124,7 @@ MoveIt! framework and registers known conditions."
                                        reference-frame)
                                       (t `(,reference-frame))))
                                (poses-stamped
-                                (list (tf:frame-id (car poses-stamped)))))))
+                                (list (cl-tf-datatypes:frame-id (car poses-stamped)))))))
                   (let* ((mpreq (make-message
                                  "moveit_msgs/MotionPlanRequest"
                                  :group_name planning-group
@@ -133,7 +137,7 @@ MoveIt! framework and registers known conditions."
                                   :max-tilts max-tilts
                                   :reference-orientations
                                   (mapcar (lambda (pose)
-                                            (tf:orientation pose))
+                                            (cl-transforms:orientation pose))
                                           poses-stamped))
                                  :goal_constraints
                                  (cond ((and joint-names joint-positions)
@@ -508,8 +512,7 @@ success, and `nil' otherwise."
                   "moveit_msgs/PositionIKRequest"
                   :group_name planning-group
                   :ik_link_names (vector link-name)
-                  :pose_stamped_vector (vector (tf:pose-stamped->msg
-                                                pose-stamped))
+                  :pose_stamped_vector (vector (cl-tf2:to-msg pose-stamped))
                   :robot_state (or robot-state
                                    (make-message "moveit_msgs/RobotState"))))))
     (roslisp:with-fields (solution error_code) result
@@ -615,8 +618,8 @@ as only the final configuration IK is generated."
             :link_name link-name
             :header (make-message
                      "std_msgs/Header"
-                     :frame_id (tf:frame-id pose-stamped)
-                     :stamp (tf:stamp pose-stamped))
+                     :frame_id (cl-tf-datatypes:frame-id pose-stamped)
+                     :stamp (cl-tf-datatypes:stamp pose-stamped))
             :constraint_region
             (make-message
              "moveit_msgs/BoundingVolume"
@@ -626,7 +629,7 @@ as only the final configuration IK is generated."
                            :type (roslisp-msg-protocol:symbol-code
                                   'shape_msgs-msg:solidprimitive :sphere)
                            :dimensions (vector tolerance-radius)))
-             :primitive_poses (vector (tf:pose->msg pose-stamped)))))
+             :primitive_poses (vector (cl-tf2:to-msg pose-stamped)))))
           :orientation_constraints
           (vector
            (make-message
@@ -635,15 +638,15 @@ as only the final configuration IK is generated."
             :link_name link-name
             :header (make-message
                      "std_msgs/Header"
-                     :frame_id (tf:frame-id pose-stamped)
-                     :stamp (tf:stamp pose-stamped))
+                     :frame_id (cl-tf-datatypes:frame-id pose-stamped)
+                     :stamp (cl-tf-datatypes:stamp pose-stamped))
             :orientation
             (make-message
              "geometry_msgs/Quaternion"
-             :x (tf:x (tf:orientation pose-stamped))
-             :y (tf:y (tf:orientation pose-stamped))
-             :z (tf:z (tf:orientation pose-stamped))
-             :w (tf:w (tf:orientation pose-stamped)))
+             :x (cl-transforms:x (cl-transforms:orientation pose-stamped))
+             :y (cl-transforms:y (cl-transforms:orientation pose-stamped))
+             :z (cl-transforms:z (cl-transforms:orientation pose-stamped))
+             :w (cl-transforms:w (cl-transforms:orientation pose-stamped)))
             :absolute_x_axis_tolerance tolerance-radius
             :absolute_y_axis_tolerance tolerance-radius
             :absolute_z_axis_tolerance tolerance-radius))))
@@ -668,10 +671,10 @@ as only the final configuration IK is generated."
                                       :stamp (roslisp:ros-time)
                                       :frame_id reference-frame)
                 :orientation (make-message "geometry_msgs/Quaternion"
-                                           :x (tf:x reference-orientation)
-                                           :y (tf:y reference-orientation)
-                                           :z (tf:z reference-orientation)
-                                           :w (tf:w reference-orientation))
+                                           :x (cl-transforms:x reference-orientation)
+                                           :y (cl-transforms:y reference-orientation)
+                                           :z (cl-transforms:z reference-orientation)
+                                           :w (cl-transforms:w reference-orientation))
                 :link_name link-name
                 :absolute_x_axis_tolerance max-tilt
                 :absolute_y_axis_tolerance max-tilt
@@ -682,12 +685,17 @@ as only the final configuration IK is generated."
 
 (defun check-base-pose-validity (pose-stamped)
   (with-lock-held (*moveit-pose-validity-check-lock*)
-    (let* ((pose-stamped-oc (cl-tf2:ensure-pose-stamped-transformed
-                             *tf2* pose-stamped "odom_combined" :use-current-ros-time t))
-           (origin (tf:origin pose-stamped-oc))
-           (orientation (tf:orientation pose-stamped-oc)))
+    (let* ((pose-stamped-oc (cl-tf2:transform-pose
+                             *tf2-buffer*
+                             :pose (cl-tf-datatypes:copy-pose-stamped
+                                    pose-stamped
+                                    :stamp (roslisp:ros-time)) ; <- use current time
+                             :target-frame designators-ros:*odom-frame*
+                             :timeout cram-roslisp-common:*tf-default-timeout*))
+           (origin (cl-transforms:origin pose-stamped-oc))
+           (orientation (cl-transforms:orientation pose-stamped-oc)))
       (let ((adv (roslisp:advertise "/dhdhdh" "geometry_msgs/PoseStamped")))
-        (roslisp:publish adv (tf:pose-stamped->msg pose-stamped-oc)))
+        (roslisp:publish adv (cl-tf2:to-msg pose-stamped-oc)))
       (let ((result
               (roslisp:call-service
                "/check_state_validity"
@@ -703,7 +711,7 @@ as only the final configuration IK is generated."
                  (make-message
                   "std_msgs/Header"
                   :frame_id (concatenate 'string "/"
-                                         (tf:frame-id pose-stamped-oc)))
+                                         (cl-tf-datatypes:frame-id pose-stamped-oc)))
                  :joint_names (vector "virtual_joint")
                  :joint_transforms
                  (vector (make-message
@@ -711,15 +719,15 @@ as only the final configuration IK is generated."
                           :translation
                           (make-message
                            "geometry_msgs/Vector3"
-                           :x (tf:x origin)
-                           :y (tf:y origin)
-                           :z (tf:z origin))
+                           :x (cl-transforms:x origin)
+                           :y (cl-transforms:y origin)
+                           :z (cl-transforms:z origin))
                           :rotation
                           (make-message
                            "geometry_msgs/Quaternion"
-                           :x (tf:x orientation)
-                           :y (tf:y orientation)
-                           :z (tf:z orientation)
-                           :w (tf:w orientation)))))))))
+                           :x (cl-transforms:x orientation)
+                           :y (cl-transforms:y orientation)
+                           :z (cl-transforms:z orientation)
+                           :w (cl-transforms:w orientation)))))))))
         (with-fields (valid) result
           valid)))))

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -99,7 +99,7 @@
    ;; Display
    display-robot-state
    set-object-color)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:desig-properties #:shape #:dimensions #:box #:cylinder
                      #:sphere #:cone #:round #:name #:yellow
                      #:color))

--- a/cram_moveit/src/utils.lisp
+++ b/cram_moveit/src/utils.lisp
@@ -34,40 +34,49 @@
      (stamp header) stamp
      (frame_id header) child-frame-id;frame-id
      (child_frame_id) frame-id;child-frame-id
-     (x translation transform) (tf:x translation)
-     (y translation transform) (tf:y translation)
-     (z translation transform) (tf:z translation)
-     (x rotation transform) (tf:x rotation)
-     (y rotation transform) (tf:y rotation)
-     (z rotation transform) (tf:z rotation)
-     (w rotation transform) (tf:w rotation))))
+     (x translation transform) (cl-transforms:x translation)
+     (y translation transform) (cl-transforms:y translation)
+     (z translation transform) (cl-transforms:z translation)
+     (x rotation transform) (cl-transforms:x rotation)
+     (y rotation transform) (cl-transforms:y rotation)
+     (z rotation transform) (cl-transforms:z rotation)
+     (w rotation transform) (cl-transforms:w rotation))))
 
 (defun transform->msg (transform)
   (with-fields (rotation translation) transform
     (make-message
      "geometry_msgs/Transform"
-     (x translation) (tf:x translation)
-     (y translation) (tf:y translation)
-     (z translation) (tf:z translation)
-     (x rotation) (tf:x rotation)
-     (y rotation) (tf:y rotation)
-     (z rotation) (tf:z rotation)
-     (w rotation) (tf:w rotation))))
+     (x translation) (cl-transforms:x translation)
+     (y translation) (cl-transforms:y translation)
+     (z translation) (cl-transforms:z translation)
+     (x rotation) (cl-transforms:x rotation)
+     (y rotation) (cl-transforms:y rotation)
+     (z rotation) (cl-transforms:z rotation)
+     (w rotation) (cl-transforms:w rotation))))
 
 (defun pose-distance (link-frame pose-stamped)
   "Returns the distance of stamped pose `pose-stamped' from the origin
 coordinates of link `link-frame'. This can be for example used for
 checking how far away a given grasp pose is from the gripper frame."
-  (tf:v-dist (tf:make-identity-vector)
-             (tf:origin (cl-tf2:ensure-pose-stamped-transformed
-                         *tf2* pose-stamped link-frame :use-current-ros-time t))))
+  (cl-transforms:v-dist (cl-transforms:make-identity-vector)
+                        (cl-transforms:origin
+                         (cl-tf2:transform-pose
+                          *tf2-buffer*
+                          :pose pose-stamped
+                          :target-frame link-frame
+                          :timeout cram-roslisp-common:*tf-default-timeout*
+                          :use-current-ros-time t))))
 
 (defun motion-length (link-name planning-group pose-stamped
                         &key allowed-collision-objects
                           highlight-links)
   (let* ((pose-stamped-transformed
-           (cl-tf2:ensure-pose-stamped-transformed
-            *tf2* pose-stamped "/torso_lift_link" :use-current-ros-time t))
+           (cl-tf2:transform-pose
+            *tf2-buffer*
+            :pose pose-stamped
+            :target-frame "torso_lift_link"
+            :timeout cram-roslisp-common:*tf-default-timeout*
+            :use-current-ros-time t))
          (state-0 (moveit:plan-link-movement
                    link-name planning-group
                    pose-stamped-transformed


### PR DESCRIPTION
This is a part of a series of pull requests concerning the switch from TF to TF2.
All the PRs are:

roslisp_common: https://github.com/ros/roslisp_common/pull/23
cram_highlevel: https://github.com/cram-code/cram_highlevel/pull/46
cram_physics: https://github.com/cram-code/cram_physics/pull/23
cram_pr2: https://github.com/cram-code/cram_pr2/pull/10
cram_bridge: https://github.com/cram-code/cram_bridge/pull/21

There is still a problem with TF for projection as the joint state publisher from moveit interferes with the transforms published from projection. This should not affect the execution on the real robot.

One important change is to use ```transform-pose``` instead of ```ensure-pose-...``` as the latter would block infinitely if a transform would not be provided to TF. The function ```transfrom-pose``` has an argument called ```timeout``` which specifies in seconds how long to wait for the transform before giving up. The default value is specified in ```cram-roslisp-common:*tf-default-timeout*```. So, before starting your scenarios set it up for a reasonable value, e.g. 10 seconds or more when working on a real robot.