### PR TITLE
Created a compute-fk function and exported it.

### DIFF
--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -266,6 +266,25 @@ bridge.")
            (moveit)
            "Removed `~a' from environment server." name))))))
 
+(defun clear-all-moveit-collision-objects ()
+  (let* ((obj-msg (roslisp:make-msg
+                   "moveit_msgs/CollisionObject"
+                   id ""
+                   operation (roslisp-msg-protocol:symbol-code
+                              'moveit_msgs-msg:collisionobject
+                              :remove)))
+         (world-msg (roslisp:make-msg
+                     "moveit_msgs/PlanningSceneWorld"
+                     collision_objects (vector obj-msg)))
+         (scene-msg (roslisp:make-msg
+                     "moveit_msgs/PlanningScene"
+                     world world-msg
+                     is_diff t)))
+    (prog1 (roslisp:publish *planning-scene-publisher* scene-msg)
+      (roslisp:ros-info
+       (moveit)
+       "Removed every collision object from environment server."))))
+
 (defmacro without-collision-objects (object-names &body body)
   `(unwind-protect
         (progn

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -129,7 +129,7 @@ bridge.")
       (set-collision-object-pose name pose-stamped))))
 
 (defun unregister-collision-object (name)
-  (let ((name (string name)))
+  (let ((name (string-upcase (string name))))
     (setf *known-collision-objects*
           (remove name *known-collision-objects*
                   :test (lambda (name object)

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -354,13 +354,14 @@ bridge.")
             (mesh-shapes (slot-value col-obj 'mesh-shapes))
             (plane-shapes (slot-value col-obj 'plane-shapes))
             (time (roslisp:ros-time)))
-        (unless (tf:wait-for-transform
-                 *tf*
-                 :timeout 5.0
-                 :time time
-                 :source-frame (tf:frame-id current-pose-stamped)
-                 :target-frame target-link)
-          (cpl:fail 'pose-not-transformable-into-link))
+;; The lines below seem outdated. Remove?
+        ;;(unless (tf:wait-for-transform
+        ;;         *tf*
+        ;;         :timeout 5.0
+        ;;         :time time
+        ;;         :source-frame (tf:frame-id current-pose-stamped)
+        ;;         :target-frame target-link)
+        ;;  (cpl:fail 'pose-not-transformable-into-link))
         (let* ((pose-in-link (cl-tf2:ensure-pose-stamped-transformed
                               *tf2* (tf:copy-pose-stamped
                                      current-pose-stamped

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -209,7 +209,7 @@ bridge.")
         do (add-collision-object (slot-value object 'name) t)))
 
 (defun add-collision-object (name &optional pose-stamped quiet)
-  (let* ((name (string name))
+  (let* ((name (string-upcase (string name)))
          (col-obj (named-collision-object name))
          (pose-stamped (or pose-stamped
                            (collision-object-pose name))))
@@ -245,7 +245,7 @@ bridge.")
             (publish-object-colors)))))))
 
 (defun remove-collision-object (name)
-  (let* ((name (string name))
+  (let* ((name (string-upcase (string name)))
          (col-obj (named-collision-object name)))
     (when col-obj
       (let* ((obj-msg (roslisp:make-msg
@@ -289,7 +289,7 @@ bridge.")
 
 (defun attach-collision-object-to-link (name target-link
                                         &key current-pose-stamped touch-links)
-  (let* ((name (string name))
+  (let* ((name (string-upcase (string name)))
          (col-obj (named-collision-object name))
          (current-pose-stamped (or current-pose-stamped
                                    (collision-object-pose name))))
@@ -345,7 +345,7 @@ bridge.")
 
 (defun detach-collision-object-from-link (name target-link
                                           &key current-pose-stamped)
-  (let* ((name (string name))
+  (let* ((name (string-upcase (string name)))
          (col-obj (named-collision-object name))
          (current-pose-stamped (or current-pose-stamped
                                    (collision-object-pose name))))

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -114,7 +114,7 @@ bridge.")
                                         plane-shapes
                                         pose-stamped
                                         color)
-  (let ((name (string-upcase (string name)))
+  (let* ((name (string-upcase (string name)))
         (obj (or (named-collision-object name)
                  (let ((obj-create
                          (make-instance 'collision-object

--- a/cram_moveit/src/collision-environment.lisp
+++ b/cram_moveit/src/collision-environment.lisp
@@ -373,14 +373,6 @@ bridge.")
             (mesh-shapes (slot-value col-obj 'mesh-shapes))
             (plane-shapes (slot-value col-obj 'plane-shapes))
             (time (roslisp:ros-time)))
-;; The lines below seem outdated. Remove?
-        ;;(unless (tf:wait-for-transform
-        ;;         *tf*
-        ;;         :timeout 5.0
-        ;;         :time time
-        ;;         :source-frame (tf:frame-id current-pose-stamped)
-        ;;         :target-frame target-link)
-        ;;  (cpl:fail 'pose-not-transformable-into-link))
         (let* ((pose-in-link (cl-tf2:ensure-pose-stamped-transformed
                               *tf2* (tf:copy-pose-stamped
                                      current-pose-stamped

--- a/cram_moveit/src/display.lisp
+++ b/cram_moveit/src/display.lisp
@@ -61,7 +61,7 @@
                                 (object-name . (r g b a)) assignment
                               (make-message
                                "moveit_msgs/ObjectColor"
-                               (id) (symbol-name object-name)
+                               (id) (string-upcase (string object-name))
                                (r color) r
                                (g color) g
                                (b color) b

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -562,7 +562,7 @@ Parameters:
 
 :constraints constraints-msg defines other kinematic constraints on the state.
 
-Returns a list of lists: ((\"state validity" valid) (\"contacts\" contacts) (\"cost sources\" cost-sources) (\"constraint check result\" constraint-result))."
+Returns a list of lists: ((\"state validity\" valid) (\"contacts\" contacts) (\"cost sources\" cost-sources) (\"constraint check result\" constraint-result))."
   (let* ((result (roslisp:call-service "/check_state_validity"
                                        "moveit_msgs/GetStateValidity"
                                        :robot_state robot-state-msg

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -524,7 +524,7 @@ Parameters:
                  (coerce name-vector 'list)
                  (coerce pose-stamped-vector 'list)))))
 
-(defun compute-ik (link-name planning-group pose-stamped &key robot-state)
+(defun compute-ik (link-name planning-group pose-stamped &key robot-state (avoid-collisions T))
   "Computes an inverse kinematics solution (if possible) of the given
 kinematics goal (given the link name `link-name' to position, the
 `planning-group' to take into consideration, and the final goal pose
@@ -538,6 +538,7 @@ success, and `nil' otherwise."
                   "moveit_msgs/PositionIKRequest"
                   :group_name planning-group
                   :ik_link_names (vector link-name)
+                  :avoid_collisions (if avoid-collisions T nil)
                   :pose_stamped_vector (vector (tf:pose-stamped->msg
                                                 pose-stamped))
                   :robot_state (or robot-state

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -551,6 +551,15 @@ success, and `nil' otherwise."
           (signal-moveit-error val))
         solution))))
 
+(defun check-state-validity (robot-state-msg planning-group-name constraints-msg)
+  (let* ((result (roslisp:call-service "/check_state_validity"
+                                       "moveit_msgs/GetStateValidity"
+                                       :robot_state robot-state-msg
+                                       :group_name planning-group-name
+                                       :constraints constraints-msg)))
+    (roslisp:with-fields (valid contacts cost_sources constraint_result) result
+      (list (list "state validity" valid) (list "contacts" contacts) (list "cost sources" cost_sources) (list "constraint check result" constraint_result)))))
+
 (defun plan-link-movements (link-name planning-group poses-stamped
                             &key allowed-collision-objects
                               touch-links default-collision-entries

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -524,7 +524,6 @@ Parameters:
                  (coerce name-vector 'list)
                  (coerce pose-stamped-vector 'list)))))
 
-
 (defun compute-ik (link-name planning-group pose-stamped &key robot-state)
   "Computes an inverse kinematics solution (if possible) of the given
 kinematics goal (given the link name `link-name' to position, the

--- a/cram_moveit/src/moveit.lisp
+++ b/cram_moveit/src/moveit.lisp
@@ -503,7 +503,8 @@ leaving their values to the executing controller."
 
 (defun compute-fk (link-names &key robot-state)
   "Computes the pose of named links, given robot-state. Will return
-a list of cl-transform:pose objects.
+a list of (name pose-stamped) pairs, in which name is a string and 
+pose-stamped is a cl-tf-datatypes:pose-stamped.
 
 Parameters:
 
@@ -518,14 +519,11 @@ Parameters:
                   :fk_link_names names
                   :robot_state (or robot-state
                                    (make-message "moveit_msgs/RobotState")))))
-       (roslisp:with-fields (pose_stamped) result
-         (mapcar (lambda (a)
-                         (roslisp:with-fields (pose) a
-                           (roslisp:with-fields ((tx (x position)) (ty (y position)) (tz (z position)) (qw (w orientation)) (qx (x orientation)) (qy (y orientation)) (qz (z orientation))) pose
-                             (cl-transforms:make-transform
-                               (cl-transforms:make-3d-vector tx ty tz)
-                                 (cl-transforms:make-quaternion qx qy qz qw)))))
-                 (coerce pose_stamped 'list)))))
+       (roslisp:with-fields ((pose-stamped-vector pose_stamped) (name-vector fk_link_names)) result
+         (mapcar (lambda (a b) (list a b))
+                 (coerce name-vector 'list)
+                 (coerce pose-stamped-vector 'list)))))
+
 
 (defun compute-ik (link-name planning-group pose-stamped &key robot-state)
   "Computes an inverse kinematics solution (if possible) of the given

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -44,6 +44,7 @@
   #:cram-plan-failures)
   (:export
    ;; Functions
+   get-planning-scene-info
    move-link-pose
    plan-link-movement
    plan-link-movements

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -63,6 +63,7 @@
    detach-collision-object-from-link
    get-joint-value
    set-collision-object-pose
+   compute-fk
    compute-ik
    execute-trajectory
    merge-trajectories

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -44,6 +44,7 @@
   #:cram-plan-failures)
   (:export
    ;; Functions
+   check-state-validity
    get-planning-scene-info
    get-collision-matrix-entry
    set-collision-matrix-entry

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -45,6 +45,10 @@
   (:export
    ;; Functions
    get-planning-scene-info
+   get-collision-matrix-entry
+   set-collision-matrix-entry
+   set-planning-scene-collision-matrix
+   combine-collision-matrices
    move-link-pose
    plan-link-movement
    plan-link-movements

--- a/cram_moveit/src/package.lisp
+++ b/cram_moveit/src/package.lisp
@@ -45,6 +45,7 @@
   (:export
    ;; Functions
    check-state-validity
+   clear-all-moveit-collision-objects
    get-planning-scene-info
    get-collision-matrix-entry
    set-collision-matrix-entry

--- a/cram_moveit/src/planning-scene.lisp
+++ b/cram_moveit/src/planning-scene.lisp
@@ -41,7 +41,7 @@
                 (make-message "moveit_msgs/PlanningSceneComponents"
                               :components components)))
 
-(defun get-planning-scene-info (&key scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
+(defun get-planning-scene-info (&key scene-settings robot-state robot-state-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
   "Function to query the state of the planning scene. What information is present depends on which &key parameters are set to non-nil.
 
 The response is a list of pairs (string object), where string names the information contained in object.
@@ -50,11 +50,11 @@ A list of possible queries follows.
 
 :scene-settings T will result in (\"planning scene name\" ps-name-string) (\"robot model name\" rm-name-string) to be added to the response.
 
-:robot-states-attached-objects T will result in (\"robot state with attached objects\" robot-state-msg) to be added to the response.
+:robot-state-attached-objects T will result in (\"robot state with attached objects\" robot-state-msg) to be added to the response.
 
-:robot-states T, if :robot-states-attached-objects is nil, will result in (\"robot state\" robot-state-msg) to be added to the response.
+:robot-state T, if :robot-state-attached-objects is nil, will result in (\"robot state\" robot-state-msg) to be added to the response.
 
-If both :robot-states and :robot-states-attached-objects are T, the response is as shown for :robot-states-attached-objects T.
+If both :robot-state and :robot-state-attached-objects are T, the response is as shown for :robot-state-attached-objects T.
 
 :world-object-names T will result in (\"world object names\" list-of-strings) to be added to the response.
 
@@ -70,8 +70,9 @@ If both :robot-states and :robot-states-attached-objects are T, the response is 
 
 :object-colors T will result in (\"object colors\" vector-of-object-color-msg) to be added to the response."
   (let* ((components (apply #'logior (mapcar (lambda (a b) (if a (roslisp-msg-protocol:symbol-code 'moveit_msgs-msg:planningscenecomponents b) 0))
-                                   (list scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
-                                   (list :scene_settings :robot_states :robot_states_attached_objects :world_object_names 
+                                   (list scene-settings robot-state robot-state-attached-objects world-object-names 
+                                         world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
+                                   (list :scene_settings :robot_state :robot_state_attached_objects :world_object_names 
                                          :world_object_geometry :octomap :transforms :allowed_collision_matrix :link_padding_and_scaling :object_colors))))
         (result (get-planning-scene components)))
           (roslisp:with-fields ((allowed-collision-matrix-f (allowed_collision_matrix scene)) 
@@ -85,7 +86,7 @@ If both :robot-states and :robot-states-attached-objects are T, the response is 
                                 (collision-objects-f (collision_objects world scene))
                                 (octomap-f (octomap world scene))) result
             (let ((retq (append (if scene-settings (list (list "planning scene name" name-f) (list "robot model name" robot-model-name-f)))
-                                (if robot-states-attached-objects (list (list "robot state with attached objects" robot-state-f) (if robot-states (list (list "robot state" robot-state-f)))))
+                                (if robot-state-attached-objects (list (list "robot state with attached objects" robot-state-f)) (if robot-state (list (list "robot state" robot-state-f))))
                                 (if transforms (list (list "fixed frame transforms" fixed-frame-transforms-f)))
                                 (if allowed-collision-matrix (list (list "allowed collision matrix" (collision-matrix-msg->collision-matrix allowed-collision-matrix-f))))
                                 (if link-padding-and-scaling (list (list "link padding" link-padding-f) (list "link scaling" link-scaling-f)))

--- a/cram_moveit/src/planning-scene.lisp
+++ b/cram_moveit/src/planning-scene.lisp
@@ -42,11 +42,60 @@
                               :components components)))
 
 (defun get-planning-scene-info (&key scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
-  (let ((components (apply #'logior (mapcar (lambda (a b) (if a (roslisp-msg-protocol:symbol-code 'moveit_msgs-msg:planningscenecomponents b) 0))
+  "Function to query the state of the planning scene. What information is present depends on which &key parameters are set to non-nil.
+
+The response is a list of pairs (string object), where string names the information contained in object.
+
+A list of possible queries follows.
+
+:scene-settings T will result in (\"planning scene name\" ps-name-string) (\"robot model name\" rm-name-string) to be added to the response.
+
+:robot-states-attached-objects T will result in (\"robot state with attached objects\" robot-state-msg) to be added to the response.
+
+:robot-states T, if :robot-states-attached-objects is nil, will result in (\"robot state\" robot-state-msg) to be added to the response.
+
+If both :robot-states and :robot-states-attached-objects are T, the response is as shown for :robot-states-attached-objects T.
+
+:world-object-names T will result in (\"world object names\" list-of-strings) to be added to the response.
+
+:world-object-geometry T will result in (\"world object geometry\" vector-of-collision-object-msgs) to be added to the response.
+
+:octomap T will result in (\"octomap\" octomap-msg) to be added to the response.
+
+:transforms T will result in (\"fixed frame transforms\" vector-of-pose-stamped-msgs) to be added to the response.
+
+:allowed-collision-matrix T will result in (\"allowed collision matrix\" allowed-collision-matrix-msg) to be added to the response.
+
+:link-padding-and-scaling T will result in (\"link padding\" vector-of-link-padding-msg) (\"link scaling\" vector-of-link-scaling-msg) to be added to the response.
+
+:object-colors T will result in (\"object colors\" vector-of-object-color-msg) to be added to the response."
+  (let* ((components (apply #'logior (mapcar (lambda (a b) (if a (roslisp-msg-protocol:symbol-code 'moveit_msgs-msg:planningscenecomponents b) 0))
                                    (list scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
                                    (list :scene_settings :robot_states :robot_states_attached_objects :world_object_names 
-                                         :world_object_geometry :octomap :transforms :allowed_collision_matrix :link_padding_and_scaling :object_colors)))))
-       (get-planning-scene components)))
+                                         :world_object_geometry :octomap :transforms :allowed_collision_matrix :link_padding_and_scaling :object_colors))))
+        (result (get-planning-scene components)))
+          (roslisp:with-fields ((allowed-collision-matrix-f (allowed_collision_matrix scene)) 
+                                (fixed-frame-transforms-f (fixed_frame_transforms scene))
+                                (link-padding-f (link_padding scene))
+                                (link-scaling-f (link_scale scene))
+                                (name-f (name scene))
+                                (object-colors-f (object_colors scene))
+                                (robot-model-name-f (robot_model_name scene))
+                                (robot-state-f (robot_state scene))
+                                (collision-objects-f (collision_objects world scene))
+                                (octomap-f (octomap world scene))) result
+            (let ((retq (append (if scene-settings (list (list "planning scene name" name-f) (list "robot model name" robot-model-name-f)))
+                                (if robot-states-attached-objects (list (list "robot state with attached objects" robot-state-f) (if robot-states (list (list "robot state" robot-state-f)))))
+                                (if transforms (list (list "fixed frame transforms" fixed-frame-transforms-f)))
+                                (if allowed-collision-matrix (list (list "allowed collision matrix" allowed-collision-matrix-f)))
+                                (if link-padding-and-scaling (list (list "link padding" link-padding-f) (list "link scaling" link-scaling-f)))
+                                (if object-colors (list (list "object colors" object-colors-f)))
+                                (if octomap (list (list "octomap" octomap-f)))
+                                (if world-object-geometry (list (list "world object geometry" collision-objects-f)))
+                                (if world-object-names (list (list "world object names" (mapcar (lambda (a) 
+                                                                                                  (roslisp:with-fields ((name (id))) a name)) 
+                                                                                                (coerce collision-objects-f 'list))))))))
+              retq))))
 
 (defun get-allowed-collision-matrix ()
   (get-planning-scene

--- a/cram_moveit/src/planning-scene.lisp
+++ b/cram_moveit/src/planning-scene.lisp
@@ -41,6 +41,13 @@
                 (make-message "moveit_msgs/PlanningSceneComponents"
                               :components components)))
 
+(defun get-planning-scene-info (&key scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
+  (let ((components (apply #'logior (mapcar (lambda (a b) (if a (roslisp-msg-protocol:symbol-code 'moveit_msgs-msg:planningscenecomponents b) 0))
+                                   (list scene-settings robot-states robot-states-attached-objects world-object-names world-object-geometry octomap transforms allowed-collision-matrix link-padding-and-scaling object-colors)
+                                   (list :scene_settings :robot_states :robot_states_attached_objects :world_object_names 
+                                         :world_object_geometry :octomap :transforms :allowed_collision_matrix :link_padding_and_scaling :object_colors)))))
+       (get-planning-scene components)))
+
 (defun get-allowed-collision-matrix ()
   (get-planning-scene
    (roslisp-msg-protocol:symbol-code


### PR DESCRIPTION
I thought it would be nice to have some reasonably convenient way to get link poses.

Other changes: 

1) tiny fixes to the collision-object name handling. It seems the intent was to have the *known-collision-objects* list contain objects with uppercase names, but this was not ensured via register-collision-object, nor payed attention to in unregister-collision-object. As a quick fix, both these functions now will make the name parameter uppercase.

Suggestion for future fixes: have *known-collision-objects* be a hash table and allow general strings (not just uppercase) as names.

2) added a key parameter avoid-collisions to compute-ik, defaulting to T.

An avoid-collisions key parameter should be there in the CRAM bridge, since MoveIt! offers this option, and it may be useful to ask for IK computations with/without collision checks.

Something to discuss is the default value. In the master version, this is nil. In the proposed change, this is T, so there's an interface change here. I thought it made sense however to only return IK solutions that are actually consistent with the environment of the robot, and leave it to the informed user to explicitly specify that they don't care about obstacles when issuing an IK request.

3) added a get-planning-scene-info function: an exported version of get-planning-scene, that uses key params.

4) Exported some functions to work with allowed collision matrices (get/set entries, combine matrices, set planning scene acms).

5) Created and exported a function to allow checking state validity via MoveIt!'s /check_state_validity service.

6) Created and exported a function to allow computation of cartesian paths via MoveIt!'s /compute_cartesian_path service.

7) Added and exported a function to clear all moveit collision objects (specifically, those in the collision world; the ones attached to the robot will remain-- this may need to change).

8) Added a &key parameter to allow passing path constraints to move-link-pose and plan-link-movement[s].